### PR TITLE
add padding

### DIFF
--- a/sign.py
+++ b/sign.py
@@ -12,8 +12,16 @@ if len(argv) != 3:
   exit(0)
 
 fi=open(argv[1], 'rb')
-a=pack('<LLQ',0,5,stat(argv[1]).st_size)+fi.read()
+data=fi.read()
 fi.close()
+orig_len=len(data)
+padded_len=((orig_len + 15) & (-16))
+if orig_len == padded_len:
+	padded=data
+else:
+	padded=data+'\x80'
+	padded=padded.ljust(padded_len, '\0')
+a=pack('<LLQ',0,5,padded_len)+padded
 c=cmac.CMAC(algorithms.AES(pack('QQ',0,0)), backend=backend)
 c.update(a)
 d=c.finalize()


### PR DESCRIPTION
Hello, my jetson tx2 (jetpack 4.3 R32.3.1) show 
[0003.172] I> T18x: Authenticate kernel-dtb (bin_type 21), max size 0x100000
[0003.179] E> Storage boot failed, err: 1075118082
on dtb signed by sign.py whithout padding, with padding - no error